### PR TITLE
CouchDB tile_attribute

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1177,10 +1177,13 @@ class CacheConfiguration(ConfigurationBase):
 
         md_template = CouchDBMDTemplate(self.conf['cache'].get('tile_metadata', {}))
         tile_id = self.conf['cache'].get('tile_id')
+        
+        tile_attribute = self.conf['cache'].get('tile_attribute')
 
         return CouchDBCache(url=url, db_name=db_name,
             file_ext=file_ext, tile_grid=grid_conf.tile_grid(),
-            md_template=md_template, tile_id_template=tile_id)
+            md_template=md_template, tile_id_template=tile_id,
+            tile_attribute=tile_attribute)
 
     def _riak_cache(self, grid_conf, file_ext):
         from mapproxy.cache.riak import RiakCache

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -137,6 +137,7 @@ cache_types = {
         },
         'tile_id': str(),
         'tile_lock_dir': str(),
+        'tile_attribute': str(),
     },
     's3': {
         'bucket_name': str(),


### PR DESCRIPTION
Needed for Couchbase.  Expired tiles do not delete attachments. Cache parameter **tile_attribute** sets tile into doc attribute. Storage is larger then attachment but automatically removed.

cache:
  type: couchdb
  tile_attribute: tile
